### PR TITLE
Always convert nil field value to nil

### DIFF
--- a/lib/firebirdex/query.ex
+++ b/lib/firebirdex/query.ex
@@ -28,6 +28,7 @@ defmodule Firebirdex.Query do
       params
     end
 
+    defp convert_value({_, _ , _, _, _}, {_name, nil}), do: nil
     defp convert_value({_, :long, scale, _, _}, {_name, v}) when scale < 0 do
       Decimal.new(to_string(v))
     end


### PR DESCRIPTION
Hello,

I had an error on a decimal database field containing a nil value.
The to_string() in Firebirdex.Query.convert_value(...) converts the nil to "", but then the Decimal.new() function generates an error:
`iex> Decimal.new("")
** (Decimal.Error) : number parsing syntax: ""
    (decimal 2.0.0) lib/decimal.ex:1094: Decimal.new/1`

I have added an additional convert_value, which always converts nil values simply to nil values, because I think it is the right behaviour to return nil in the result set when there is a nil value in the database, and at the same time no other convert_value functions have to deal with nil values.

Can you please review, and merge if this is OK with you.

Best regards,

Hermanius.

