### PR TITLE
free_statement :close to :drop in ping

### DIFF
--- a/lib/firebirdex.ex
+++ b/lib/firebirdex.ex
@@ -21,7 +21,8 @@ defmodule Firebirdex do
     query = %Query{name: "", statement: IO.iodata_to_binary(statement)}
 
     case DBConnection.prepare_execute(conn, query, params, opts) do
-      {:ok, _query, result} ->
+      {:ok, query, result} ->
+        DBConnection.close(conn,query)
         {:ok, result}
 
       otherwise ->

--- a/lib/firebirdex/connection.ex
+++ b/lib/firebirdex/connection.ex
@@ -109,9 +109,11 @@ defmodule Firebirdex.Connection do
   end
 
   @impl true
-  def handle_close(_query, _opts, state) do
-    with {:ok, conn} <- :efirebirdsql_protocol.close(state.conn) do
+  def handle_close(query, _opts, state) do
+    with {:ok, conn} <- :efirebirdsql_protocol.free_statement(state.conn, query.stmt, :drop) do
       {:ok, nil, %__MODULE__{state | conn: conn}}
+    else
+      otherwise -> {:error,otherwise,state}
     end
   end
 

--- a/lib/firebirdex/connection.ex
+++ b/lib/firebirdex/connection.ex
@@ -39,7 +39,7 @@ defmodule Firebirdex.Connection do
     with {:ok,statement} <- :efirebirdsql_protocol.allocate_statement(conn),
       {:ok,statement} <- :efirebirdsql_protocol.prepare_statement(sql, conn, statement),
       {:ok,_} <- :efirebirdsql_protocol.execute(conn, statement),
-      {:ok,_} <- :efirebirdsql_protocol.free_statement(conn,statement,:close)
+      {:ok,_} <- :efirebirdsql_protocol.free_statement(conn,statement,:drop)
     do
       {:ok,state}
       # Uncomment following line for testing purposes. It will disonnect/reconnect randomly
@@ -50,6 +50,7 @@ defmodule Firebirdex.Connection do
   end
 
   @impl true
+  @spec checkout(any) :: {:ok, any}
   def checkout(state) do
     {:ok, state}
   end


### PR DESCRIPTION
Hi,

Currently in the Firebirdex.Connection.ping function we do a :close in the :efirebirdsql.free_statement.
As it turns out, a :close is to close open cursors, while we intend to drop prepared statements from the database server.
With the :close all the queries in the ping are cached on the server, and can crash the server after some time. Especially when using a pool of connections through the pool_size connection option.
Therefore the :close was changed to :drop in the free_statement function inside the ping function.

I think I have also a fix for Issue #3 
I have rewritten the handle_close to close the prepared statement in the query, and I'm calling DBConnection.close on every Firebirdex.query, so the prepared query is closed after the query has executed.

Best regards.