### PR TITLE
free_statement after query

### DIFF
--- a/lib/firebirdex.ex
+++ b/lib/firebirdex.ex
@@ -21,7 +21,8 @@ defmodule Firebirdex do
     query = %Query{name: "", statement: IO.iodata_to_binary(statement)}
 
     case DBConnection.prepare_execute(conn, query, params, opts) do
-      {:ok, _query, result} ->
+      {:ok, query, result} ->
+        DBConnection.close(conn,query)
         {:ok, result}
 
       otherwise ->

--- a/lib/firebirdex/connection.ex
+++ b/lib/firebirdex/connection.ex
@@ -109,8 +109,8 @@ defmodule Firebirdex.Connection do
 
   @impl true
   def handle_close(query, _opts, state) do
-    with {:ok, conn} <- :efirebirdsql_protocol.free_statement(state.conn, query.stmt, :drop) do
-      {:ok, nil, %__MODULE__{state | conn: conn}}
+    with {:ok, _conn} <- :efirebirdsql_protocol.free_statement(state.conn, query.stmt, :drop) do
+      {:ok, nil, state}
     else
       otherwise -> {:error,otherwise,state}
     end

--- a/lib/firebirdex/connection.ex
+++ b/lib/firebirdex/connection.ex
@@ -108,9 +108,11 @@ defmodule Firebirdex.Connection do
   end
 
   @impl true
-  def handle_close(_query, _opts, state) do
-    with {:ok, conn} <- :efirebirdsql_protocol.close(state.conn) do
+  def handle_close(query, _opts, state) do
+    with {:ok, conn} <- :efirebirdsql_protocol.free_statement(state.conn, query.stmt, :drop) do
       {:ok, nil, %__MODULE__{state | conn: conn}}
+    else
+      otherwise -> {:error,otherwise,state}
     end
   end
 


### PR DESCRIPTION
Update to do a DBConnection.close after every Firebirdex.query. Also update to Connection.handle_close to freeing the statement in stead of closing the connection as discussed in Issue #3 

Do you think it is OK like this?