### PR TITLE
Treat invalid timestamps as nil

### DIFF
--- a/lib/firebirdex/query.ex
+++ b/lib/firebirdex/query.ex
@@ -52,8 +52,10 @@ defmodule Firebirdex.Query do
       v
     end
     defp convert_value({_, :timestamp, _, _, _}, {_name, {{year, month, day}, {hour, minute, second, microsecond}}}, _charset) do
-      {:ok, v} = NaiveDateTime.new(year, month, day, hour, minute, second, microsecond)
-      v
+      case NaiveDateTime.new(year, month, day, hour, minute, second, microsecond) do
+          {:ok, datetime} -> datetime
+          {:error, _} -> nil # Treat invalid timestamps as nil
+        end
     end
     defp convert_value({_, :time_tz, _, _, _}, {_name, {{hour, minute, second, microsecond}, tz, offset}}, _charset) do
       d = Date.utc_today

--- a/lib/firebirdex/query.ex
+++ b/lib/firebirdex/query.ex
@@ -30,50 +30,81 @@ defmodule Firebirdex.Query do
       params
     end
 
-    defp convert_value({_, _ , _, _, _}, {_name, nil}, _charset), do: nil
+    defp convert_value({_, _, _, _, _}, {_name, nil}, _charset), do: nil
+
     defp convert_value({_, :long, scale, _, _}, {_name, v}, _charset) when scale < 0 do
       Decimal.new(to_string(v))
     end
+
     defp convert_value({_, :short, scale, _, _}, {_name, v}, _charset) when scale < 0 do
       Decimal.new(to_string(v))
     end
+
     defp convert_value({_, :int64, scale, _, _}, {_name, v}, _charset) when scale < 0 do
       Decimal.new(to_string(v))
     end
+
     defp convert_value({_, :quad, scale, _, _}, {_name, v}, _charset) when scale < 0 do
       Decimal.new(to_string(v))
     end
+
     defp convert_value({_, :date, _, _, _}, {_name, {year, month, day}}, _charset) do
-      {:ok, v} = Date.new(year, month, day)
-      v
+      case Date.new(year, month, day) do
+        {:ok, date} -> date
+        # Treat invalid date as nil
+        {:error, _} -> nil
+      end
     end
-    defp convert_value({_, :time, _, _, _}, {_name, {hour, minute, second, microsecond}}, _charset) do
+
+    defp convert_value(
+           {_, :time, _, _, _},
+           {_name, {hour, minute, second, microsecond}},
+           _charset
+         ) do
       {:ok, v} = Time.new(hour, minute, second, microsecond)
       v
     end
-    defp convert_value({_, :timestamp, _, _, _}, {_name, {{year, month, day}, {hour, minute, second, microsecond}}}, _charset) do
+
+    defp convert_value(
+           {_, :timestamp, _, _, _},
+           {_name, {{year, month, day}, {hour, minute, second, microsecond}}},
+           _charset
+         ) do
       case NaiveDateTime.new(year, month, day, hour, minute, second, microsecond) do
-          {:ok, datetime} -> datetime
-          {:error, _} -> nil # Treat invalid timestamps as nil
-        end
+        {:ok, datetime} -> datetime
+        # Treat invalid timestamps as nil
+        {:error, _} -> nil
+      end
     end
-    defp convert_value({_, :time_tz, _, _, _}, {_name, {{hour, minute, second, microsecond}, tz, offset}}, _charset) do
-      d = Date.utc_today
+
+    defp convert_value(
+           {_, :time_tz, _, _, _},
+           {_name, {{hour, minute, second, microsecond}, tz, offset}},
+           _charset
+         ) do
+      d = Date.utc_today()
       {:ok, dt} = NaiveDateTime.new(d.year, d.month, d.day, hour, minute, second)
       dttz1 = DateTime.from_naive!(dt, tz)
       {:ok, dttz2} = DateTime.shift_zone(dttz1, offset)
       {:ok, v} = Time.new(dttz2.hour, dttz2.minute, dttz2.second, microsecond)
       {v, offset}
     end
-    defp convert_value({_, :timestamp_tz, _, _, _}, {_name, {{year, month, day}, {hour, minute, second, microsecond}, tz, offset}}, _charset) do
+
+    defp convert_value(
+           {_, :timestamp_tz, _, _, _},
+           {_name, {{year, month, day}, {hour, minute, second, microsecond}, tz, offset}},
+           _charset
+         ) do
       {:ok, dt} = NaiveDateTime.new(year, month, day, hour, minute, second, microsecond)
       dttz = DateTime.from_naive!(dt, tz)
       {:ok, v} = DateTime.shift_zone(dttz, offset)
       v
     end
+
     defp convert_value({_, _, _, _, _}, {_name, v}, charset) when is_binary(v) do
       Encoding.to_string!(v, charset)
     end
+
     defp convert_value({_, _, _, _, _}, {_name, v}, _charset) do
       v
     end
@@ -81,6 +112,7 @@ defmodule Firebirdex.Query do
     defp convert_row(row, [], [], _charset) do
       Enum.reverse(row)
     end
+
     defp convert_row(row, rest_columns, rest_row, charset) do
       [c | rest_columns] = rest_columns
       [v | rest_row] = rest_row
@@ -88,11 +120,13 @@ defmodule Firebirdex.Query do
     end
 
     def decode(query, result, _opts) do
-      rows = if result.rows == nil do
-        result.rows
-      else
-        Enum.map(result.rows, &(convert_row([], result.desc, &1, query.charset)))
-      end
+      rows =
+        if result.rows == nil do
+          result.rows
+        else
+          Enum.map(result.rows, &convert_row([], result.desc, &1, query.charset))
+        end
+
       %Result{result | rows: rows, num_rows: result.num_rows}
     end
   end


### PR DESCRIPTION
I am working with a legacy database (Firebird 3.0), using ecto_firebird, there are some fields that are of type timestamp that by definition are not nullable, sometimes when inserting the records the value was not available and "0100-00-00 00:00:00" was used instead as a placeholder, this value was generating the error "** (MatchError) no match of right hand side value: {:error, :invalid_date}".
The change in this commit has been made to consider this case and any other invalid date as nil