### PR TITLE
Fix connection crash when the server errors while reading a result set

### DIFF
--- a/lib/firebirdex/connection.ex
+++ b/lib/firebirdex/connection.ex
@@ -94,12 +94,20 @@ defmodule Firebirdex.Connection do
     params = Enum.map(params, &convert_param(&1, econn(state.conn, :charset)))
     case :efirebirdsql_protocol.execute(state.conn, query.stmt, params) do
       {:ok, stmt} ->
-        {:ok, rows, stmt} = :efirebirdsql_protocol.fetchall(state.conn, stmt)
-        desc = :efirebirdsql_protocol.columns(stmt)
-        columns = Enum.map(desc, &(column_name(&1)))
-        {:ok, num_rows} = :efirebirdsql_protocol.rowcount(state.conn, stmt)
-        {:ok, stmt} = :efirebirdsql_protocol.free_statement(state.conn, stmt, :drop)
-        {:ok, %Query{query | stmt: stmt}, %Result{desc: desc, columns: columns, num_rows: num_rows, rows: rows}, %__MODULE__{state | conn: state.conn}}
+        # efirebirdsql can return {:error, ...} mid-read from fetchall/rowcount/free_statement
+        # when the server reports an error while retrieving rows. A strict `=` match crashed the
+        # connection process with {badmatch, {:error,...}}, hiding the real SQL error. Route any
+        # of them to the same error clause used by `execute`. The success path is unchanged.
+        with {:ok, rows, stmt} <- :efirebirdsql_protocol.fetchall(state.conn, stmt),
+             desc = :efirebirdsql_protocol.columns(stmt),
+             columns = Enum.map(desc, &column_name(&1)),
+             {:ok, num_rows} <- :efirebirdsql_protocol.rowcount(state.conn, stmt),
+             {:ok, stmt} <- :efirebirdsql_protocol.free_statement(state.conn, stmt, :drop) do
+          {:ok, %Query{query | stmt: stmt}, %Result{desc: desc, columns: columns, num_rows: num_rows, rows: rows}, %__MODULE__{state | conn: state.conn}}
+        else
+          {:error, number, reason} ->
+            {:error, %Error{number: number, reason: reason, statement: query.statement}, %__MODULE__{state | conn: state.conn}}
+        end
       {:error, number, reason} ->
         {:error, %Error{number: number, reason: reason, statement: query.statement}, %__MODULE__{state | conn: state.conn}}
     end


### PR DESCRIPTION
## Motivation

When the Firebird server reports an error *after* a statement has been prepared and
executed — i.e. during row retrieval (a per-row arithmetic overflow / division by zero, an
invalid runtime conversion, a cursor that dies mid-read) — `efirebirdsql` returns
`{:error, ErrNo, Msg}` from `fetchall` / `rowcount` / `free_statement`.

`Firebirdex.Connection.handle_execute/4` matches the success path of those three calls with a
strict `=`, so any such error raises `{:badmatch, {:error, ...}}`. The connection process
crashes, DBConnection restarts it, and the real SQL error is lost — every mid-read failure
surfaces as the same opaque connection error.

Errors that occur at *prepare* time (syntax, unknown column) are already handled by the
`execute/4` error clause; this gap is specifically the *mid-read* path.

Reproduction (seen on Firebird 3.0, version-independent) — a per-row division by zero:

```elixir
{:ok, conn} = Firebirdex.start_link(opts)
# `t` has rows; the row where id = MAX(id) divides by zero
Firebirdex.query(conn, "SELECT id, 1/(id - (SELECT MAX(id) FROM t)) FROM t", [])
#=> ** (MatchError) no match of right hand side value:
#=>    {:error, 335544778,
#=>     "arithmetic exception, numeric overflow, or string truncation ...
#=>      Integer divide by zero. ..."}
#=>     (firebirdex) lib/firebirdex/connection.ex: Firebirdex.Connection.handle_execute/4
```

`isql` returns a clean arithmetic-exception error for the same query, confirming the server is
fine — this is an adapter robustness issue.

## What changed

`handle_execute/4` now wraps the success branch in `with/else`, routing an
`{:error, number, reason}` from `fetchall`, `rowcount` or `free_statement` to the same error
clause already used for `execute`. The order of operations and the resulting `%Result{}` are
unchanged; the `desc`/`columns` bindings stay as plain `=`. Only inputs that previously crashed
now return a handleable `{:error, %Firebirdex.Error{}}` and keep the connection alive — there is
no case that worked before and changes now. No public signature changes.

## Verification

Before/after against Firebird 3.0.8:

| Scenario | Before | After |
|---|---|---|
| `SELECT` that fails mid-read | `{:badmatch, {:error, 335544778, ...}}` → dead connection | `{:error, %Firebirdex.Error{number: 335544778}}`, connection alive (next query OK) |
| normal `SELECT` | `{:ok, %Result{}}` | `{:ok, %Result{}}` (identical) |
| `INSERT ... RETURNING` (normal and erroring) | unchanged | unchanged |
