### PR TITLE
Fix transaction rollback and nested savepoints

### DIFF
--- a/lib/firebirdex/connection.ex
+++ b/lib/firebirdex/connection.ex
@@ -9,7 +9,29 @@ defmodule Firebirdex.Connection do
   defstruct [
     :conn,
     :transaction_status,
+    savepoint_depth: 0,
   ]
+
+  # Firebird, unlike PostgreSQL, does not stack savepoints that share a name:
+  # re-declaring a savepoint with an existing name replaces it, so a fixed name
+  # makes the outer level of a nested transaction impossible to roll back. Name
+  # each level uniquely by its depth instead.
+  defp savepoint_name(depth), do: "firebirdex_savepoint_#{depth}"
+
+  # After a hard commit/rollback the transaction is closed; Firebird requires an active
+  # transaction for any statement, so we open a fresh autocommit base. This makes writes
+  # outside a Repo.transaction commit (with commit_retaining the base was left without
+  # autocommit and they were lost) and returns the status to :idle so the next transaction
+  # can start again.
+  defp rebase_autocommit(conn) do
+    case :efirebirdsql_protocol.begin_transaction(true, conn) do
+      {:ok, conn} ->
+        {:ok, %Result{}, %__MODULE__{conn: conn, transaction_status: :idle}}
+      {:error, errno, reason, conn} ->
+        {:disconnect, %Error{number: errno, reason: reason},
+         %__MODULE__{conn: conn, transaction_status: :idle}}
+    end
+  end
 
   @impl true
   def connect(opts) do
@@ -54,7 +76,10 @@ defmodule Firebirdex.Connection do
     charset = econn(state.conn, :charset)
 
     {:ok, stmt} = :efirebirdsql_protocol.unallocate_statement(to_string(query))
-    {:ok, %Query{query | stmt: stmt, charset: charset}, %__MODULE__{state | conn: state.conn, transaction_status: :transaction}}
+    # Do NOT force transaction_status here. Setting it to :transaction makes it stick after
+    # the first query, so handle_begin's `status == :idle` guard stops starting the real
+    # transaction -> everything runs on the autocommit base and rollback has nothing to undo.
+    {:ok, %Query{query | stmt: stmt, charset: charset}, %__MODULE__{state | conn: state.conn}}
   end
 
   defp convert_param(%Decimal{} = value, _charset) do
@@ -119,6 +144,9 @@ defmodule Firebirdex.Connection do
   def handle_begin(opts, %{conn: conn, transaction_status: status} = s) do
     case Keyword.get(opts, :mode, :transaction) do
       :transaction when status == :idle ->
+        # Close the autocommit base before opening the explicit transaction, so it is not
+        # left orphaned (otherwise the connection accumulates 2 transactions per Repo.transaction).
+        _ = :efirebirdsql_protocol.commit(conn)
         case :efirebirdsql_protocol.begin_transaction(false, conn) do
           {:ok, conn} ->
             {:ok, %Result{}, %__MODULE__{conn: conn, transaction_status: :transaction}}
@@ -127,10 +155,13 @@ defmodule Firebirdex.Connection do
         end
 
       :savepoint when status == :transaction ->
-        case :efirebirdsql_protocol.exec_immediate("SAVEPOINT firebirdex_savepoint", conn) do
+        depth = s.savepoint_depth + 1
+        case :efirebirdsql_protocol.exec_immediate("SAVEPOINT #{savepoint_name(depth)}", conn) do
           :ok ->
-            {:ok, %Result{}, s}
-          {:error, _errno, _reason, _conn} ->
+            {:ok, %Result{}, %{s | savepoint_depth: depth}}
+          # exec_immediate/2 returns a 3-tuple {:error, errno, reason}; matching the 4-tuple
+          # form crashed with CaseClauseError whenever a savepoint statement failed.
+          {:error, _errno, _reason} ->
             {:error, s}
         end
 
@@ -144,18 +175,22 @@ defmodule Firebirdex.Connection do
   def handle_commit(opts, %{conn: conn, transaction_status: status} = s) do
     case Keyword.get(opts, :mode, :transaction) do
       :transaction when status == :transaction ->
-        case :efirebirdsql_protocol.commit_retaining(conn) do
+        # Hard commit (closes the transaction) and reopen the autocommit base, so later
+        # standalone writes commit and the next transaction can start.
+        case :efirebirdsql_protocol.commit(conn) do
           :ok ->
-            {:ok, %Result{}, s}
+            rebase_autocommit(conn)
           {:error, _errno, _reason} ->
             {:error, s}
         end
 
       :savepoint when status == :transaction ->
-        case :efirebirdsql_protocol.exec_immediate("RELEASE SAVEPOINT firebirdex_savepoint", conn) do
+        depth = s.savepoint_depth
+        case :efirebirdsql_protocol.exec_immediate("RELEASE SAVEPOINT #{savepoint_name(depth)}", conn) do
           :ok ->
-            {:ok, %Result{}, s}
-          {:error, _errno, _reason, _conn} ->
+            {:ok, %Result{}, %{s | savepoint_depth: max(depth - 1, 0)}}
+          # exec_immediate/2 returns a 3-tuple (see handle_begin).
+          {:error, _errno, _reason} ->
             {:error, s}
         end
 
@@ -168,18 +203,21 @@ defmodule Firebirdex.Connection do
   def handle_rollback(opts, %{conn: conn, transaction_status: status} = s) do
     case Keyword.get(opts, :mode, :transaction) do
       :transaction when status == :transaction ->
-        case :efirebirdsql_protocol.rollback_retaining(conn) do
+        # Hard rollback and reopen the autocommit base (same reason as handle_commit).
+        case :efirebirdsql_protocol.rollback(conn) do
           :ok ->
-            {:ok, %Result{}, s}
+            rebase_autocommit(conn)
           {:error, _errno, _reason} ->
             {:error, s}
         end
 
       :savepoint when status == :transaction ->
-        case :efirebirdsql_protocol.exec_immediate("ROLLBACK TO SAVEPOINT firebirdex_savepoint", conn) do
+        depth = s.savepoint_depth
+        case :efirebirdsql_protocol.exec_immediate("ROLLBACK TO SAVEPOINT #{savepoint_name(depth)}", conn) do
           :ok ->
-            {:ok, %Result{}, s}
-          {:error, _errno, _reason, _conn} ->
+            {:ok, %Result{}, %{s | savepoint_depth: max(depth - 1, 0)}}
+          # exec_immediate/2 returns a 3-tuple (see handle_begin).
+          {:error, _errno, _reason} ->
             {:error, s}
         end
 


### PR DESCRIPTION
## Motivation

`Repo.transaction(fn -> ...; Repo.rollback(...) end)` can silently fail to roll back: the rows
written inside the transaction remain after the rollback, and no error is raised. Nested
transactions (savepoints) compound the problem. There are four distinct root causes, all in
`Firebirdex.Connection`.

**1. `handle_prepare/3` forces `transaction_status: :transaction` on every prepare.**
Once any statement has been prepared on a pooled connection, the status is stuck at
`:transaction`. When `handle_begin/2` is later called to start a transaction, its
`:transaction when status == :idle` guard no longer matches, so it falls through to the no-op
clause and **never opens a real transaction**. Every statement then runs inside the autocommit
base transaction that `connect` opens (`isc_tpb_autocommit`), committing immediately, so
`rollback_retaining` has nothing to undo. This is intermittent ("sometimes the rollback doesn't
work") because it depends on whether the pooled connection had a prior query.

**2. `handle_commit/2` / `handle_rollback/2` use `commit_retaining` / `rollback_retaining`.**
These keep the transaction open. Together with the orphaned autocommit base from (1), a
connection accumulates two transactions per `Repo.transaction`, and a standalone write *after* a
transaction is never committed (lost when the connection is recycled).

**3. Nested savepoints share the fixed name `firebirdex_savepoint`.**
In Firebird — unlike PostgreSQL — re-declaring a savepoint with an existing name *replaces* it,
so rolling back the outer level of a nested transaction does not revert it.

**4. The `:savepoint` error clauses match a 4-tuple** `{:error, errno, reason, conn}`, but
`exec_immediate/2` returns a 3-tuple `{:error, errno, reason}`. Any failing savepoint statement
raises `CaseClauseError` instead of returning a handleable error.

Reproduction (Firebird 3.0):

```elixir
# (1)+(2) — run a query first so the pooled connection's status is stuck:
Repo.query!("SELECT 1 FROM RDB$DATABASE")
Repo.transaction(fn -> Repo.insert!(%Row{id: 1}); Repo.rollback(:boom) end)
# bug: row id=1 is still present afterwards (observed from a separate connection)
```

```sql
-- (3) same-named nested savepoints, at protocol level:
SAVEPOINT sp; INSERT a; SAVEPOINT sp; INSERT b; ROLLBACK TO sp; ROLLBACK TO sp;
-- bug: 1 row remains (outer level not reverted); with unique names: 0 rows
```

## What changed

1. `handle_prepare/3` no longer sets `transaction_status`. (It has no contract requiring it; the
   DBConnection docs say a callback should only report a status it can determine without side
   effects.)
2. The `:transaction` clauses of `handle_commit/2` and `handle_rollback/2` use the non-retaining
   `commit/1` / `rollback/1` (which close the transaction) and then reopen a clean autocommit
   base via `begin_transaction(true, conn)`, returning the status to `:idle`. No orphaned
   transaction; standalone writes after a transaction commit; the next transaction starts
   cleanly. If reopening the autocommit base fails after a successful commit/rollback, the
   callback returns `{:disconnect, %Firebirdex.Error{}, state}` so DBConnection recycles the
   connection (a valid `handle_commit/2`/`handle_rollback/2` return per the behaviour).
3. Savepoints are named uniquely per nesting depth (`firebirdex_savepoint_<n>`, tracked by a new
   `savepoint_depth` field on the connection state).
4. The `:savepoint` error clauses match the 3-tuple that `exec_immediate/2` actually returns.
   (The `:transaction` clause of `handle_begin/2` keeps the 4-tuple, which is correct —
   `begin_transaction/2` returns a 4-tuple.)

## Verification

Before/after against Firebird 3.0.8 (writes checked from a separate connection):

| Scenario | Before | After |
|---|---|---|
| rollback after a prior query | row persists | reverts |
| standalone write after a transaction | lost on recycle | committed |
| transactions left open per `Repo.transaction` | 2 (one orphaned) | 0 |
| nested savepoint, outer rollback | outer not reverted | reverts |
| failing savepoint statement | `CaseClauseError` | handleable `{:error, ...}` |

An end-to-end Ecto/Ash test that previously crashed under the test sandbox with
`CaseClauseError: "Unable to find savepoint with name FIREBIRDEX_SAVEPOINT in transaction
context"` now passes.

## Note on behavior

This restores real transactions, which (correctly) reintroduces the lock contention that the
autocommit-only behavior masked — that is inherent to having working transactions, not a
regression. Firebird resolves conflicts through its WAIT mode and deadlock detection; consumers
that need to fail fast on a lock conflict can set `isc_tpb_lock_timeout` via the `lock_timeout`
connection option.
